### PR TITLE
627-add link to patreon from pricing page

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -52,7 +52,7 @@ layout: homepage
   <div class="container">
     <div class="row">
       <div class="col">
-        <h3 class="font-weight-normal text-center mb-5 mb-sm-3">You can also install Monica <a href="https://github.com/monicahq/monica#get-started">on your own server</a>, and support it financially <a href="">on Patreon</a>.</h3>
+        <h3 class="font-weight-normal text-center mb-5 mb-sm-3">You can also install Monica <a href="https://github.com/monicahq/monica#get-started">on your own server</a>, and support it financially <a href="https://www.patreon.com/monicahq">on Patreon</a>.</h3>
         <p class="text-center mb-5">And by the way, if you do contribute to the project on GitHub, you’ll have access to the paid version for free.</p>
       </div>
     </div>


### PR DESCRIPTION
Solution to https://github.com/monicahq/monica/issues/627 - people clicking your Patreon link weren't easily getting there.